### PR TITLE
patch: increase timeout

### DIFF
--- a/spec/conf.js
+++ b/spec/conf.js
@@ -5,6 +5,10 @@
 
 exports.config = {
     framework: 'mocha',
+    mochaOpts: {
+        ui: 'bdd',
+        timeout: 10 * 1000
+    },
     sauceUser: process.env.SAUCE_USER,
     sauceKey: process.env.SAUCE_KEY,
     specs: [ 'test.js' ]


### PR DESCRIPTION
## Context

By default, mocha will time out after 2 seconds. This may be too short of a run, as it is latency-dependent. 

## Objective

This change aims to increase the timeout to a reasonable 10 seconds: long enough for
the test to accomplish what it's supposed to and short enough that it should timeout when there are other factors involved

EDIT: changed objective from 30 seconds to 10 seconds